### PR TITLE
checkDID() implementation

### DIFF
--- a/eosio-did-chain-registry.json
+++ b/eosio-did-chain-registry.json
@@ -5,24 +5,21 @@
             {
                 "id": "https://eos.greymass.com",
                 "type": [
-                    "LinkedDomains",
-                    "EosioNodeos"
+                    "LinkedDomains"
                 ],
                 "serviceEndpoint": "https://eos.greymass.com"
             },
             {
                 "id": "https://eos.dfuse.eosnation.io",
                 "type": [
-                    "LinkedDomains",
-                    "EosioDfuseRest"
+                    "LinkedDomains"
                 ],
                 "serviceEndpoint": "https://eos.dfuse.eosnation.io"
             },
             {
                 "id": "wss://eos.dfuse.eosnation.io",
                 "type": [
-                    "LinkedDomains",
-                    "EosioDfuseWebsocket"
+                    "LinkedDomains"
                 ],
                 "serviceEndpoint": "wss://eos.dfuse.eosnation.io"
             }
@@ -34,8 +31,7 @@
             {
                 "id": "https://jungle3.cryptolions.io",
                 "type": [
-                    "LinkedDomains",
-                    "EosioNodeos"
+                    "LinkedDomains"
                 ],
                 "serviceEndpoint": "https://jungle3.cryptolions.io"
             }
@@ -47,8 +43,7 @@
             {
                 "id": "https://telos.greymass.com",
                 "type": [
-                    "LinkedDomains",
-                    "EosioNodeos"
+                    "LinkedDomains"
                 ],
                 "serviceEndpoint": "https://telos.greymass.com"
             }
@@ -60,8 +55,7 @@
             {
                 "id": "https://api.xec.cryptolions.io",
                 "type": [
-                    "LinkedDomains",
-                    "EosioNodeos"
+                    "LinkedDomains"
                 ],
                 "serviceEndpoint": "https://api.xec.cryptolions.io"
             }

--- a/eosio-did-chain-registry.json
+++ b/eosio-did-chain-registry.json
@@ -1,0 +1,70 @@
+{
+    "eos": {
+        "chainId": "aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906",
+        "service": [
+            {
+                "id": "https://eos.greymass.com",
+                "type": [
+                    "LinkedDomains",
+                    "EosioNodeos"
+                ],
+                "serviceEndpoint": "https://eos.greymass.com"
+            },
+            {
+                "id": "https://eos.dfuse.eosnation.io",
+                "type": [
+                    "LinkedDomains",
+                    "EosioDfuseRest"
+                ],
+                "serviceEndpoint": "https://eos.dfuse.eosnation.io"
+            },
+            {
+                "id": "wss://eos.dfuse.eosnation.io",
+                "type": [
+                    "LinkedDomains",
+                    "EosioDfuseWebsocket"
+                ],
+                "serviceEndpoint": "wss://eos.dfuse.eosnation.io"
+            }
+        ]
+    },
+    "eos:testnet:jungle": {
+        "chainId": "2a02a0053e5a8cf73a56ba0fda11e4d92e0238a4a2aa74fccf46d5a910746840",
+        "service": [
+            {
+                "id": "https://jungle3.cryptolions.io",
+                "type": [
+                    "LinkedDomains",
+                    "EosioNodeos"
+                ],
+                "serviceEndpoint": "https://jungle3.cryptolions.io"
+            }
+        ]
+    },
+    "telos": {
+        "chainId": "4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11",
+        "service": [
+            {
+                "id": "https://telos.greymass.com",
+                "type": [
+                    "LinkedDomains",
+                    "EosioNodeos"
+                ],
+                "serviceEndpoint": "https://telos.greymass.com"
+            }
+        ]
+    },
+    "europechain": {
+        "chainId": "f778f7d2f124b110e0a71245b310c1d0ac1a0edd21f131c5ecb2e2bc03e8fe2e",
+        "service": [
+            {
+                "id": "https://api.xec.cryptolions.io",
+                "type": [
+                    "LinkedDomains",
+                    "EosioNodeos"
+                ],
+                "serviceEndpoint": "https://api.xec.cryptolions.io"
+            }
+        ]
+    }
+}

--- a/eosio-did-chain-registry.json
+++ b/eosio-did-chain-registry.json
@@ -4,23 +4,17 @@
         "service": [
             {
                 "id": "https://eos.greymass.com",
-                "type": [
-                    "LinkedDomains"
-                ],
+                "type": "LinkedDomains",
                 "serviceEndpoint": "https://eos.greymass.com"
             },
             {
                 "id": "https://eos.dfuse.eosnation.io",
-                "type": [
-                    "LinkedDomains"
-                ],
+                "type": "LinkedDomains",
                 "serviceEndpoint": "https://eos.dfuse.eosnation.io"
             },
             {
                 "id": "wss://eos.dfuse.eosnation.io",
-                "type": [
-                    "LinkedDomains"
-                ],
+                "type": "LinkedDomains",
                 "serviceEndpoint": "wss://eos.dfuse.eosnation.io"
             }
         ]
@@ -30,9 +24,7 @@
         "service": [
             {
                 "id": "https://jungle3.cryptolions.io",
-                "type": [
-                    "LinkedDomains"
-                ],
+                "type": "LinkedDomains",
                 "serviceEndpoint": "https://jungle3.cryptolions.io"
             }
         ]
@@ -42,9 +34,7 @@
         "service": [
             {
                 "id": "https://telos.greymass.com",
-                "type": [
-                    "LinkedDomains"
-                ],
+                "type": "LinkedDomains",
                 "serviceEndpoint": "https://telos.greymass.com"
             }
         ]
@@ -54,9 +44,7 @@
         "service": [
             {
                 "id": "https://api.xec.cryptolions.io",
-                "type": [
-                    "LinkedDomains"
-                ],
+                "type": "LinkedDomains",
                 "serviceEndpoint": "https://api.xec.cryptolions.io"
             }
         ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,15 @@
-import { ResolverRegistry } from "did-resolver";
-import { resolve } from './resolver';
+import { ResolverRegistry, DIDResolutionOptions, DIDResolutionResult, ParsedDID, Resolver } from "did-resolver";
+import { resolve, Registry } from './resolver';
 
-export function getResolver(): ResolverRegistry {
-  return { 'eosio': resolve }
+export function getResolver(registry?: Registry): ResolverRegistry {
+  return { 
+    'eosio': async (
+                did: string,
+                parsed: ParsedDID,
+                didResolver: Resolver,
+                options: DIDResolutionOptions
+              ): Promise<DIDResolutionResult> => { 
+                return resolve(did, parsed, didResolver, options, registry) 
+              } 
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,8 @@
-import { ResolverRegistry, DIDResolutionOptions, DIDResolutionResult, ParsedDID, Resolver } from "did-resolver";
-import { resolve, Registry } from './resolver';
+import { ResolverRegistry } from "did-resolver";
+import { resolve } from './resolver';
 
-export function getResolver(registry?: Registry): ResolverRegistry {
+export function getResolver(): ResolverRegistry {
   return { 
-    'eosio': async (
-                did: string,
-                parsed: ParsedDID,
-                didResolver: Resolver,
-                options: DIDResolutionOptions
-              ): Promise<DIDResolutionResult> => { 
-                return resolve(did, parsed, didResolver, options, registry) 
-              } 
+    'eosio': resolve
   }
 }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,6 +1,12 @@
 import { DIDDocument, DIDResolutionOptions, DIDResolutionResult, ParsedDID, Resolver } from "did-resolver"
 const registry = require('../eosio-did-chain-registry.json');
 
+const ERROR_RESULT = {
+    didResolutionMetadata: { error: 'invalidDid' },
+    didDocument: null,
+    didDocumentMetadata: {}
+};
+
 const SUBJECT_ID = `([a-z1-5.]{0,12}[a-z1-5])`;
 const CHAIN_ID   = new RegExp( `^([A-Fa-f0-9]{64}):${SUBJECT_ID}$` )
 const CHAIN_NAME = new RegExp(
@@ -66,6 +72,10 @@ export async function resolve(
     options: DIDResolutionOptions): Promise<DIDResolutionResult> {
 
     const registryEntry = checkDID(parsed);
+
+    if(!registryEntry.chain) {
+        return ERROR_RESULT;
+    }
 
     const eosioAccount = await fetchAccount(registryEntry, did, parsed, options);
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,5 +1,6 @@
 import { DIDDocument, DIDResolutionOptions, DIDResolutionResult, ParsedDID, Resolver } from "did-resolver"
-const registry = require('../eosio-did-chain-registry.json');
+
+const defaultRegistry: Registry = require('../eosio-did-chain-registry.json');
 
 const ERROR_RESULT = {
     didResolutionMetadata: { error: 'invalidDid' },
@@ -13,47 +14,36 @@ const CHAIN_NAME = new RegExp(
     `^(([a-z1-5.]{0,12}[a-z1-5])((:[a-z1-5.]{0,12}[a-z1-5])+)?):${SUBJECT_ID}$`
 )
 
-function findChainByID(chainId: string) {
-    registry.map((chain: any, chainName: string) => {
-        if(chain.chainId === chainId) return chain;
-    });
-}
+function checkDID(parsed: ParsedDID, registry: Registry): MethodId | undefined {
 
-function findChainByName(chainName: string) {
-    return registry[chainName];
-}
-
-/**
- * Checks the method-specific-id, parses it into chainId/chainName 
- * and subject (account name) and fetches the correlating chain from 
- * the registry.
- * If the method-specific-id is invalid or no matching chain was 
- * found, then an empty object is returned.
- * 
- * @param parsed 
- * @returns { {chain?: object, subject?: string} }
- */
-function checkDID(parsed: ParsedDID) {
-    const partsID = parsed.id.match(CHAIN_ID);
-    if(partsID) {
-        return {
-            chain: findChainByID(partsID[1]),
-            subject: partsID[partsID.length - 1]
-        }
-    }
-
+    // findChainByName
     const partsName = parsed.id.match(CHAIN_NAME);
     if(partsName) {
-        return {
-            chain: findChainByName(partsName[1]),
+        const entry = registry[partsName[1]];
+        if(entry) return {
+            chain: entry,
             subject: partsName[partsName.length - 1]
+        }
+        return undefined;
+    }
+    
+    // findChainById
+    const partsID = parsed.id.match(CHAIN_ID);
+    if(partsID) {
+        for (let key of Object.keys(registry)) {
+            const entry: Entry = registry[key];
+            if(entry.chainId === partsID[1]) 
+                return { 
+                    chain: entry, 
+                    subject: partsID[partsID.length - 1] 
+                };
         }
     }
 
-    return {}
+    return undefined
 }
 
-async function fetchAccount(registryEntry: object, did: string, parsed: ParsedDID, options: DIDResolutionOptions): Promise<object> {
+async function fetchAccount(methodId: MethodId, did: string, parsed: ParsedDID, options: DIDResolutionOptions): Promise<object> {
     // Find the API from registered eosio chains or from options
 
     // Fetch the eosio account
@@ -69,15 +59,22 @@ export async function resolve(
     did: string,
     parsed: ParsedDID,
     didResolver: Resolver,
-    options: DIDResolutionOptions): Promise<DIDResolutionResult> {
+    options: DIDResolutionOptions,
+    customRegistry?: Registry): Promise<DIDResolutionResult> {
+    
+    const registry: Registry = {
+        ...defaultRegistry, 
+        ...customRegistry
+    };
 
-    const registryEntry = checkDID(parsed);
+    const methodId = checkDID(parsed, registry);
 
-    if(!registryEntry.chain) {
+    if(!methodId) {
+        // invalid method-specific-id OR no matching chain in the registry
         return ERROR_RESULT;
     }
 
-    const eosioAccount = await fetchAccount(registryEntry, did, parsed, options);
+    const eosioAccount = await fetchAccount(methodId, did, parsed, options);
 
     const didDoc = createDIDDocument(eosioAccount);
 
@@ -86,4 +83,24 @@ export async function resolve(
         didDocument: didDoc,
         didDocumentMetadata: {}
     }
+}
+
+interface Service {
+    id: string,
+    type: string|string[],
+    serviceEndpoint: string
+}
+
+interface Entry {
+    chainId: string,
+    service: Service[]
+}
+
+export interface Registry {
+    [chainName: string]: Entry;
+}
+
+interface MethodId {
+    chain: Entry,
+    subject: string
 }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,6 +1,6 @@
 import { DIDDocument, DIDResolutionOptions, DIDResolutionResult, ParsedDID, Resolver } from "did-resolver"
 
-const defaultRegistry: Registry = require('../eosio-did-chain-registry.json');
+const eosioChainRegistry: Registry = require('../eosio-did-chain-registry.json');
 
 const ERROR_RESULT = {
     didResolutionMetadata: { error: 'invalidDid' },
@@ -59,12 +59,12 @@ export async function resolve(
     did: string,
     parsed: ParsedDID,
     didResolver: Resolver,
-    options: DIDResolutionOptions,
-    customRegistry?: Registry): Promise<DIDResolutionResult> {
+    options: DIDResolutionOptions
+    ): Promise<DIDResolutionResult> {
     
     const registry: Registry = {
-        ...defaultRegistry, 
-        ...customRegistry
+        ...eosioChainRegistry,
+        ...options.eosioChainRegistry
     };
 
     const methodId = checkDID(parsed, registry);

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,10 +1,53 @@
 import { DIDDocument, DIDResolutionOptions, DIDResolutionResult, ParsedDID, Resolver } from "did-resolver"
+const registry = require('../eosio-did-chain-registry.json');
 
-function checkDID(parsed: ParsedDID) {
-    // TODO check DID is valid format and structure
+const SUBJECT_ID = `([a-z1-5.]{0,12}[a-z1-5])`;
+const CHAIN_ID   = new RegExp( `^([A-Fa-f0-9]{64}):${SUBJECT_ID}$` )
+const CHAIN_NAME = new RegExp(
+    `^(([a-z1-5.]{0,12}[a-z1-5])((:[a-z1-5.]{0,12}[a-z1-5])+)?):${SUBJECT_ID}$`
+)
+
+function findChainByID(chainId: string) {
+    registry.map((chain: any, chainName: string) => {
+        if(chain.chainId === chainId) return chain;
+    });
 }
 
-async function fetchAccount(did: string, parsed: ParsedDID, options: DIDResolutionOptions): Promise<object> {
+function findChainByName(chainName: string) {
+    return registry[chainName];
+}
+
+/**
+ * Checks the method-specific-id, parses it into chainId/chainName 
+ * and subject (account name) and fetches the correlating chain from 
+ * the registry.
+ * If the method-specific-id is invalid or no matching chain was 
+ * found, then an empty object is returned.
+ * 
+ * @param parsed 
+ * @returns { {chain?: object, subject?: string} }
+ */
+function checkDID(parsed: ParsedDID) {
+    const partsID = parsed.id.match(CHAIN_ID);
+    if(partsID) {
+        return {
+            chain: findChainByID(partsID[1]),
+            subject: partsID[partsID.length - 1]
+        }
+    }
+
+    const partsName = parsed.id.match(CHAIN_NAME);
+    if(partsName) {
+        return {
+            chain: findChainByName(partsName[1]),
+            subject: partsName[partsName.length - 1]
+        }
+    }
+
+    return {}
+}
+
+async function fetchAccount(registryEntry: object, did: string, parsed: ParsedDID, options: DIDResolutionOptions): Promise<object> {
     // Find the API from registered eosio chains or from options
 
     // Fetch the eosio account
@@ -22,9 +65,9 @@ export async function resolve(
     didResolver: Resolver,
     options: DIDResolutionOptions): Promise<DIDResolutionResult> {
 
-    checkDID(parsed);
+    const registryEntry = checkDID(parsed);
 
-    const eosioAccount = await fetchAccount(did, parsed, options);
+    const eosioAccount = await fetchAccount(registryEntry, did, parsed, options);
 
     const didDoc = createDIDDocument(eosioAccount);
 

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -12,7 +12,7 @@ describe('EOSIO resolver', async () => {
   })
 
   it('Resolve a jungle testnet DID Document', async () => {
-    const jungleDid = 'did:eosio:eos:jungle:lioninjungle';
+    const jungleDid = 'did:eosio:eos:testnet:jungle:lioninjungle';
     console.log('Resolving ' + jungleDid);
     const jungleDidDocument = await resolver.resolve(jungleDid);
     console.log('DID Document:', jungleDidDocument);


### PR DESCRIPTION
**The implementation contains the following:**
Added a RegEx check to validate the method-specific-id of the DID.
If the validation succeeds, the id is parsed into chainId/chainName (chain) and accountName (subject).
After that, the corresponding chain is fetched from the chain-registry.
In case the validation fails or no corresponding chain is found, the returned object is empty.

Since the did-resolver package already checks for a valid DID Syntax, it should be enough to validate the method-specific-id.
Also, because the checkDID function now returns the chain data, I passed the result to the fetchAccount function to signal this change. That way we don't have to parse the DID again in fetchAccount.

[_I could not link the issue for some reason. Maybe @gimly-jack has to do that as the owner of the repo_.]