### PR TITLE
checkDID() implementation

### DIFF
--- a/eosio-did-chain-registry.json
+++ b/eosio-did-chain-registry.json
@@ -1,0 +1,52 @@
+{
+    "eos": {
+        "chainId": "aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906",
+        "service": [
+            {
+                "id": "https://eos.greymass.com",
+                "type": "LinkedDomains",
+                "serviceEndpoint": "https://eos.greymass.com"
+            },
+            {
+                "id": "https://eos.dfuse.eosnation.io",
+                "type": "LinkedDomains",
+                "serviceEndpoint": "https://eos.dfuse.eosnation.io"
+            },
+            {
+                "id": "wss://eos.dfuse.eosnation.io",
+                "type": "LinkedDomains",
+                "serviceEndpoint": "wss://eos.dfuse.eosnation.io"
+            }
+        ]
+    },
+    "eos:testnet:jungle": {
+        "chainId": "2a02a0053e5a8cf73a56ba0fda11e4d92e0238a4a2aa74fccf46d5a910746840",
+        "service": [
+            {
+                "id": "https://jungle3.cryptolions.io",
+                "type": "LinkedDomains",
+                "serviceEndpoint": "https://jungle3.cryptolions.io"
+            }
+        ]
+    },
+    "telos": {
+        "chainId": "4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11",
+        "service": [
+            {
+                "id": "https://telos.greymass.com",
+                "type": "LinkedDomains",
+                "serviceEndpoint": "https://telos.greymass.com"
+            }
+        ]
+    },
+    "europechain": {
+        "chainId": "f778f7d2f124b110e0a71245b310c1d0ac1a0edd21f131c5ecb2e2bc03e8fe2e",
+        "service": [
+            {
+                "id": "https://api.xec.cryptolions.io",
+                "type": "LinkedDomains",
+                "serviceEndpoint": "https://api.xec.cryptolions.io"
+            }
+        ]
+    }
+}

--- a/eosio-did-chain-registry.json
+++ b/eosio-did-chain-registry.json
@@ -11,11 +11,6 @@
                 "id": "https://eos.dfuse.eosnation.io",
                 "type": "LinkedDomains",
                 "serviceEndpoint": "https://eos.dfuse.eosnation.io"
-            },
-            {
-                "id": "wss://eos.dfuse.eosnation.io",
-                "type": "LinkedDomains",
-                "serviceEndpoint": "wss://eos.dfuse.eosnation.io"
             }
         ]
     },

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,10 +1,49 @@
 import { DIDDocument, DIDResolutionOptions, DIDResolutionResult, ParsedDID, Resolver } from "did-resolver"
 
-function checkDID(parsed: ParsedDID) {
-    // TODO check DID is valid format and structure
+const eosioChainRegistry: Registry = require('../eosio-did-chain-registry.json');
+
+const ERROR_RESULT = {
+    didResolutionMetadata: { error: 'invalidDid' },
+    didDocument: null,
+    didDocumentMetadata: {}
+};
+
+const SUBJECT_ID = `([a-z1-5.]{0,12}[a-z1-5])`;
+const CHAIN_ID   = new RegExp( `^([A-Fa-f0-9]{64}):${SUBJECT_ID}$` )
+const CHAIN_NAME = new RegExp(
+    `^(([a-z1-5.]{0,12}[a-z1-5])((:[a-z1-5.]{0,12}[a-z1-5])+)?):${SUBJECT_ID}$`
+)
+
+function checkDID(parsed: ParsedDID, registry: Registry): MethodId | undefined {
+
+    // findChainByName
+    const partsName = parsed.id.match(CHAIN_NAME);
+    if(partsName) {
+        const entry = registry[partsName[1]];
+        if(entry) return {
+            chain: entry,
+            subject: partsName[partsName.length - 1]
+        }
+        return undefined;
+    }
+    
+    // findChainById
+    const partsID = parsed.id.match(CHAIN_ID);
+    if(partsID) {
+        for (let key of Object.keys(registry)) {
+            const entry: Entry = registry[key];
+            if(entry.chainId === partsID[1]) 
+                return { 
+                    chain: entry, 
+                    subject: partsID[partsID.length - 1] 
+                };
+        }
+    }
+
+    return undefined
 }
 
-async function fetchAccount(did: string, parsed: ParsedDID, options: DIDResolutionOptions): Promise<object> {
+async function fetchAccount(methodId: MethodId, did: string, parsed: ParsedDID, options: DIDResolutionOptions): Promise<object> {
     // Find the API from registered eosio chains or from options
 
     // Fetch the eosio account
@@ -20,11 +59,22 @@ export async function resolve(
     did: string,
     parsed: ParsedDID,
     didResolver: Resolver,
-    options: DIDResolutionOptions): Promise<DIDResolutionResult> {
+    options: DIDResolutionOptions
+    ): Promise<DIDResolutionResult> {
+    
+    const registry: Registry = {
+        ...eosioChainRegistry,
+        ...options.eosioChainRegistry
+    };
 
-    checkDID(parsed);
+    const methodId = checkDID(parsed, registry);
 
-    const eosioAccount = await fetchAccount(did, parsed, options);
+    if(!methodId) {
+        // invalid method-specific-id OR no matching chain in the registry
+        return ERROR_RESULT;
+    }
+
+    const eosioAccount = await fetchAccount(methodId, did, parsed, options);
 
     const didDoc = createDIDDocument(eosioAccount);
 
@@ -33,4 +83,24 @@ export async function resolve(
         didDocument: didDoc,
         didDocumentMetadata: {}
     }
+}
+
+interface Service {
+    id: string,
+    type: string|string[],
+    serviceEndpoint: string
+}
+
+interface Entry {
+    chainId: string,
+    service: Service[]
+}
+
+export interface Registry {
+    [chainName: string]: Entry;
+}
+
+interface MethodId {
+    chain: Entry,
+    subject: string
 }

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -12,7 +12,7 @@ describe('EOSIO resolver', async () => {
   })
 
   it('Resolve a jungle testnet DID Document', async () => {
-    const jungleDid = 'did:eosio:eos:jungle:lioninjungle';
+    const jungleDid = 'did:eosio:eos:testnet:jungle:lioninjungle';
     console.log('Resolving ' + jungleDid);
     const jungleDidDocument = await resolver.resolve(jungleDid);
     console.log('DID Document:', jungleDidDocument);


### PR DESCRIPTION
In reference to Issue #1 

**Implemented the checkDID function**
- validates the method-specific-id section of the did through RegEx
- takes the chainId or the chainName and fetches the corresponding entry from the registry
- returns undefined in case no chain data is found or the validation fails
- returns the chain data and the account name on success

**Altered the resolve function**
- returns an error result in case the checkDID fails
- passes the result of the checkDID to the fetchAccount function
- the eosio-did-chain-registry is merged with user supplied registry options

**Moved the eosio-did-chain-registry.json to this repo**
- removed API types from services


This implementation solely validates the method-specific-id, since the overall DID syntax is already checked by the did-resolver package. 
Also, because the checkDID function now returns the chain data, I passed the result to the fetchAccount function to signal this change. That way we don't have to parse the DID again in fetchAccount.


_Some questions:_
How do we want to handle the registry?
Do we need to validate other parts of the DID?


[_I could not link the issue for some reason. Maybe @gimly-jack has to do that as the owner of the repo._]

Because I ended up making some changes to the [original pr](https://github.com/Gimly-Blockchain/eosio-did-resolver/pull/7), I decided to reopen it with an uncluttered branch.
Hopefully, that improves the readability and helps the review process.